### PR TITLE
Specify a single semver-compatible range for each dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,21 @@ name = "uefisettings"
 path = "src/lib/lib.rs"
 
 [dependencies]
-uefisettings_backend_thrift = { path = "thrift/rust/uefisettings_backend_thrift", version = ">=0.1.0" }
-uefisettings_spellings_db_thrift = { path = "thrift/rust/uefisettings_spellings_db_thrift", version = ">=0.1.0" }
-anyhow = ">=1.0"
+uefisettings_backend_thrift = { path = "thrift/rust/uefisettings_backend_thrift", version = "0.1.0" }
+uefisettings_spellings_db_thrift = { path = "thrift/rust/uefisettings_spellings_db_thrift", version = "0.1.0" }
+anyhow = "1.0"
 fbthrift = ">=0.0"
-clap = { package = "clap", version = ">=3.2.25", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
-log = { version = ">=0.4", features = ["kv_unstable", "kv_unstable_std"] }
-serde = { version = ">=1.0", features = ["derive", "rc"]}
-serde_json = { version = ">=1.0", features = ["float_roundtrip", "unbounded_depth"] }
-nix = { version = ">=0.26", features = ["fs", "ioctl", "mount"] }
-tempfile = ">=3.5"
-libloading = ">=0.8"
-httparse = ">=1.8"
-binrw = ">=0.10"
-rand = { version = ">=0.8", features = ["small_rng"] }
-proc-mounts = ">=0.3"
-thiserror = ">=1.0"
-env_logger = ">=0.10"
+clap = { package = "clap", version = "3.2.25", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
+log = { version = "0.4", features = ["kv_unstable", "kv_unstable_std"] }
+serde = { version = "1.0", features = ["derive", "rc"]}
+serde_json = { version = "1.0", features = ["float_roundtrip", "unbounded_depth"] }
+nix = { version = "0.27", features = ["fs", "ioctl", "mount"] }
+tempfile = "3.5"
+libloading = "0.8"
+httparse = "1.8"
+binrw = "0.13"
+rand = { version = "0.8", features = ["small_rng"] }
+proc-mounts = "0.3"
+thiserror = "1.0"
+env_logger = "0.10"
 


### PR DESCRIPTION
The dependencies specified in this project's Cargo.toml are problematic for at least 3 reasons.

- A dependency like `clap = ">=3.2.25"` means "uefisettings is compatible with every unreleased future version of clap, including v5, v6, v7, etc". That is unknowable but very likely false.

- When this project is pulled in as a dependency into a larger Cargo workspace, the versions Cargo assigns for uefisettings's dependencies will flap unpredictably, for example between thiserror v1 and v2, leading to spurious and confusing diffs.

- Uefisettings declares compatibility with crate versions that it is definitely not compatible with. For example `binrw = ">=0.10"` is listed as a dependency, but uefisettings definitely does not work when compiled against binrw 0.10. This means if someone has a project using binrw 0.10, and they add a dependency on uefisettings, uefisettings will fail to compile instead of pulling in the actual binrw dependency it needs.

```console
error[E0107]: associated type takes 0 lifetime arguments but 1 lifetime argument was supplied
    --> src/lib/hii/forms.rs:1393:29
     |
1393 |     for<'a> <T as BinRead>::Args<'a>: Default,
     |                             ^^^^---- help: remove the unnecessary generics
     |                             |
     |                             expected 0 lifetime arguments
     |
note: associated type defined here, with 0 lifetime parameters
    --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/binrw-0.10.0/src/binread/mod.rs:50:10
     |
50   |     type Args: Clone;
     |          ^^^^
```

In this PR I have matched the versions currently captured in Cargo.lock. For example I am changing `binrw = ">=0.10"` to `binrw = "0.13"` because according to the lockfile that is what uefisettings in this repo currently builds against.

https://github.com/linuxboot/uefisettings/blob/f90aed759b9c2217bea336e37ab5282616ece390/Cargo.lock#L60-L62