### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "The tool to read/get/extract and write/change/modify BIOS/UEFI se
 version = "0.1.5"
 edition = "2021"
 license = "BSD-3-Clause"
-homepage = "https://github.com/linuxboot/uefisettings"
+repository = "https://github.com/linuxboot/uefisettings"
 
 [lib]
 name = "uefisettings"


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104